### PR TITLE
添加 Playwright 测试用例

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "rollup": "^3.29.4",
     "tsx": "^4.7.2",
     "turbo": "^1.13.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@playwright/test": "^1.48.2"
   }
 }

--- a/packages/remove-redirect/.gitignore
+++ b/packages/remove-redirect/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/packages/remove-redirect/e2e/sites/51cto.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/51cto.com.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('51cto blog redirect removal', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://blog.51cto.com/transfer?https://cloud.tencent.com/product/hai',
+    'https://cloud.tencent.com/product/hai',
+    {
+      originalUrlWaitUntil: 'load',
+    },
+  )
+})

--- a/packages/remove-redirect/e2e/sites/acgbox.link.spec.ts
+++ b/packages/remove-redirect/e2e/sites/acgbox.link.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('ACG盒子链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.acgbox.link/go/?url=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+    {
+      originalUrlWaitUntil: 'load',
+    },
+  )
+})
+
+test('ACG盒子 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(page, context, 'https://www.acgbox.link/h/58.html', {
+    selectDomPath:
+      '#content > div.row.site-content.py-4.py-md-5.mb-xl-5.mb-0.mx-xxxl-n5 > div.col.mt-4.mt-sm-0 > div > div > div.site-go.mt-3 > span > a',
+  })
+  expect(href).toBe('https://www.pixiv.net/')
+})

--- a/packages/remove-redirect/e2e/sites/afdian.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/afdian.com.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('爱发电链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://afdian.com/link?target=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+
+test('爱发电 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(page, context, 'https://afdian.com/a/evanyou', {
+    selectDomPath:
+      'div.wrapper.app-view > div.vm-page > section.page-content-w100 > div > div.content-left.max-width-320 > div.gl-card.mq-0-1 > pre > a',
+  })
+  expect(href).toBe('https://cn.vuejs.org/sponsor/')
+})

--- a/packages/remove-redirect/e2e/sites/baidu.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/baidu.com.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('百度贴吧重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://tieba.baidu.com/mo/q/checkurl?url=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+test('百度搜索 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(page, context, 'https://www.baidu.com/s?wd=mmPlayer', {
+    selectDomPath: '#content_left  a',
+  })
+  expect(href).not.toMatch(/^https\:\/\/www\.baidu\.comm/)
+})

--- a/packages/remove-redirect/e2e/sites/bilibili.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/bilibili.com.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('哔哩哔哩游戏WIKI链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://game.bilibili.com/linkfilter/?url=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/bing.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/bing.com.spec.ts
@@ -1,0 +1,9 @@
+import test, { expect } from '@playwright/test'
+import { getTransformUrl } from '../utils/common'
+
+test('Bing 搜索', async ({ page, context }) => {
+  const href = await getTransformUrl(page, context, 'https://www.bing.com/search?q=mmPlayer', {
+    selectDomPath: '#b_results > li.b_algo.b_vtl_deeplinks > h2 > a',
+  })
+  expect(href).not.toMatch(/^https\:\/\/www\.bing\.comm/)
+})

--- a/packages/remove-redirect/e2e/sites/bookmarkearth.cn.spec.ts
+++ b/packages/remove-redirect/e2e/sites/bookmarkearth.cn.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('书签地球链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.bookmarkearth.cn/view/a61cf21a93d711edb9f55254005bdbf9',
+    'https://netease-music.fe-mm.com/#/music/playlist',
+  )
+})
+
+test('书签地球 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(
+    page,
+    context,
+    'https://www.bookmarkearth.cn/detail/221486638f5f4c2aa9139d08bd1bcfd2',
+    {
+      selectDomPath:
+        '#container > div > div.content-point > ul > li > ul > li:nth-child(1) > ul > li > a:nth-child(1)',
+      noWait: true,
+    },
+  )
+  expect(href).not.toMatch(/^https\:\/\/www\.bookmarkearth\.comm/)
+})

--- a/packages/remove-redirect/e2e/sites/coolapk.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/coolapk.com.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('酷安链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.coolapk.com/link?url=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/csdn.net.spec.ts
+++ b/packages/remove-redirect/e2e/sites/csdn.net.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('CSDN链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://link.csdn.net/?target=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/douban.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/douban.com.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('豆瓣链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.douban.com/link2/?url=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/facebook.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/facebook.com.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('Facebook链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.facebook.com/flx/warn/?u=https%3A%2F%2Ffe-mm.com%2F&h=AT3rQZSh11Lt_BU05Y5GdcM4AnpqrnDK2c2xhNUvIxzo6_VKIzItCrEi6udhWA6mMnQxUKCpO20vWTt-sJXSY3k_VQOBKA4SjWPIxQP_A78sEgVKHJuMM38',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/gitee.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/gitee.com.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('码云链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://gitee.com/link?target=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+
+test('码云 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(page, context, 'https://gitee.com/mirrors/vue-mmplayer', {
+    selectDomPath:
+      '#git-readme > div > div.readme-content > div.file_content.markdown-body > blob-markdown-renderer > ul:nth-child(4) > li:nth-child(1) > a',
+  })
+  expect(href).toBe('https://netease-music.fe-mm.com/')
+})

--- a/packages/remove-redirect/e2e/sites/google.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/google.com.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('Google搜索重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.google.com/url?q=https%3A%2F%2Fgithub.com%2Fmaomao1996%2Ftampermonkey-scripts',
+    'https://github.com/maomao1996/tampermonkey-scripts',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/huaban.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/huaban.com.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('花瓣网链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://huaban.com/go?pin_id=5108412769&url=weibo.com',
+    'weibo.com',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/infoq.cn.spec.ts
+++ b/packages/remove-redirect/e2e/sites/infoq.cn.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('InfoQ链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.infoq.cn/link?target=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/jianshu.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/jianshu.com.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('简书链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.jianshu.com/go-wild?ac=2&url=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+
+test('简书 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(page, context, 'https://www.jianshu.com/p/28788506c0da', {
+    selectDomPath:
+      '#__next > div._21bLU4._3kbg6I > div > div > section:nth-child(1) > article > p:nth-child(4) > a',
+  })
+  expect(href).toBe('https://pan.baidu.com/s/1ccvNa3TrmkaWdgU1nhLvGw?pwd=b5t8')
+})

--- a/packages/remove-redirect/e2e/sites/juejin.cn.spec.ts
+++ b/packages/remove-redirect/e2e/sites/juejin.cn.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('掘金链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://link.juejin.cn/?target=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+
+test('掘金 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(page, context, 'https://juejin.cn/post/6844903608622956557', {
+    selectDomPath: '#article-root > div > blockquote:nth-child(5) > p > a',
+  })
+  expect(href).toBe('https://binaryify.github.io/NeteaseCloudMusicApi')
+})

--- a/packages/remove-redirect/e2e/sites/kdocs.cn.spec.ts
+++ b/packages/remove-redirect/e2e/sites/kdocs.cn.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('金山文档链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.kdocs.cn/office/link?target=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/ld246.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/ld246.com.spec.ts
@@ -1,0 +1,15 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('链滴链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://ld246.com/forward?goto=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+    {
+      urlWaitUntil: 'domcontentloaded',
+      redirectNum: 1,
+    },
+  )
+})

--- a/packages/remove-redirect/e2e/sites/leetcode.cn.spec.ts
+++ b/packages/remove-redirect/e2e/sites/leetcode.cn.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('力扣链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://leetcode.cn/link/?target=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/nowcoder.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/nowcoder.com.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('牛客网链接重定向移除 - hd域名', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://hd.nowcoder.com/link.html?target=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+
+test('牛客网链接重定向移除 - gw-c域名', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://gw-c.nowcoder.com/api/sparta/jump/link?link=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+    {
+      redirectNum: 2,
+    },
+  )
+})
+
+test('牛客网 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(
+    page,
+    context,
+    'https://www.nowcoder.com/discuss/451073381044064256',
+    {
+      selectDomPath:
+        '#jsApp > main > div > div > div > section > div:nth-child(3) > div > div > section.post-content-box.tw-relative > div.nc-slate-editor-content > p:nth-child(27) > a',
+    },
+  )
+  expect(href).toBe('https://leetcode.cn/problems/longest-substring-without-repeating-characters/')
+})

--- a/packages/remove-redirect/e2e/sites/oschina.net.spec.ts
+++ b/packages/remove-redirect/e2e/sites/oschina.net.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('开源中国链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.oschina.net/action/GoToLink?url=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+
+test('开源中国 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(
+    page,
+    context,
+    'https://www.oschina.net/news/226616/fish-shell-be-rewritten-rust',
+    {
+      selectDomPath:
+        '#mainScreen > div.home-container > div > div.detail-body-box > div:nth-child(2) > div.main-box > div > div.article-box.box-card.box-card--shadow > div > div.article-box__content > div.detail-box > div.article-detail > div > ol > li:nth-child(1) > a',
+    },
+  )
+  expect(href).toBe('https://www.rust-lang.org/tools/install')
+})

--- a/packages/remove-redirect/e2e/sites/qq.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/qq.com.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('微信链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://weixin110.qq.com/cgi-bin/mmspamsupport-bin/newredirectconfirmcgi?midpagecode=e2faa0ee03e19e6efecf869b7f9ca0522c68d4854df6fbfa04376e4e5a76fb68051eaf8948fea39790a1cd7df4a64a26&bancode=89d3568371f79149d12922166481d28a6da76ea9bfcc9e3cdaf42f8eede7f10b',
+    'https://www.douyin.com',
+  )
+})
+
+test('微信开放社区链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://developers.weixin.qq.com/community/middlepage/href?href=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+
+test('QQ邮箱链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://mail.qq.com/cgi-bin/readtemplate?t=safety&check=false&gourl=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+
+test('PC版QQ链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://c.pc.qq.com/middlem.html?pfurl=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+
+test('腾讯文档链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://docs.qq.com/scenario/link.html?url=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+
+test('腾讯兔小巢链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://txc.qq.com/embed/phone/606094/link-jump?jump=https%3A%2F%2Fgithub.com%2Fmaomao1996%2Ftampermonkey-scripts',
+    'https://github.com/maomao1996/tampermonkey-scripts',
+  )
+})
+

--- a/packages/remove-redirect/e2e/sites/shimo.im.spec.ts
+++ b/packages/remove-redirect/e2e/sites/shimo.im.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('石墨文档链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://shimo.im/outlink/gray?url=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/so.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/so.com.spec.ts
@@ -1,0 +1,9 @@
+import test, { expect } from '@playwright/test'
+import { getTransformUrl } from '../utils/common'
+
+test('360 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(page, context, 'https://www.so.com/s?q=mmPlayer', {
+    selectDomPath: '#main > ul > li:nth-child(1) > h3 > a',
+  })
+  expect(href).not.toMatch(/^https\:\/\/www\.so\.com/)
+})

--- a/packages/remove-redirect/e2e/sites/sogou.com.ts
+++ b/packages/remove-redirect/e2e/sites/sogou.com.ts
@@ -1,0 +1,9 @@
+import test, { expect } from '@playwright/test'
+import { getTransformUrl } from '../utils/common'
+
+test('搜狗搜索 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(page, context, 'https://www.sogou.com/web?query=mmPlayer', {
+    selectDomPath: '#sogou_vr_30000000_0',
+  })
+  expect(href).not.toMatch(/^\/link\?/)
+})

--- a/packages/remove-redirect/e2e/sites/sspai.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/sspai.com.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('少数派链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://sspai.com/link?target=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})
+
+test('少数派 transform', async ({ page, context }) => {
+  const href = await getTransformUrl(page, context, 'https://sspai.com/post/71216', {
+    selectDomPath:
+      '#article-title > div.articleWidth-content > div.content.wangEditor-txt.minHeight > p:nth-child(5) > a:nth-child(1)',
+    noWait: true,
+  })
+  expect(href).toBe('https://github.com/BlackINT3/OpenArk/')
+})

--- a/packages/remove-redirect/e2e/sites/tencent.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/tencent.com.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('腾讯云开发者社区链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://cloud.tencent.com/developer/tools/blog-entry?target=https%3A%2F%2Fgithub.com%2Fmaomao1996%2FVue-mmPlayer&objectId=1829900&objectType=1',
+    'https://github.com/maomao1996/Vue-mmPlayer',
+  )
+})
+
+test('腾讯云开发者社区 搜索', async ({ page, context }) => {
+  const href = await getTransformUrl(
+    page,
+    context,
+    'https://cloud.tencent.com/developer/article/1829900',
+    {
+      selectDomPath:
+        '#__next > div > div > div.cdc-global__main > div > div > div.cdc-layout__main > div:nth-child(2) > div.mod-content > div.mod-content__markdown > div > div > p:nth-child(7) > a',
+      noWait: true,
+    },
+  )
+  expect(href).toBe('https://github.com/maomao1996/Vue-mmPlayer')
+})

--- a/packages/remove-redirect/e2e/sites/weibo.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/weibo.com.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('微博链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://weibo.cn/sinaurl?u=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/youtube.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/youtube.com.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('YouTube链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.youtube.com/redirect?q=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/yuque.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/yuque.com.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { testRedirectRemoval } from '../utils/common'
+
+test('语雀链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://www.yuque.com/r/goto?url=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/sites/zhihu.com.spec.ts
+++ b/packages/remove-redirect/e2e/sites/zhihu.com.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@playwright/test'
+import { getTransformUrl, testRedirectRemoval } from '../utils/common'
+
+test('知乎链接重定向移除', async ({ page, context }) => {
+  await testRedirectRemoval(
+    page,
+    context,
+    'https://link.zhihu.com/?target=https%3A%2F%2Ffe-mm.com',
+    'https://fe-mm.com/',
+  )
+})

--- a/packages/remove-redirect/e2e/utils/common.ts
+++ b/packages/remove-redirect/e2e/utils/common.ts
@@ -1,0 +1,136 @@
+import { BrowserContext, expect, Page } from '@playwright/test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { FEMM_ATTR_KEY } from '../../../../shared/utils/src/dom/constant'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export async function testRedirectRemoval(
+  page: Page,
+  context: BrowserContext,
+  originalUrl: string | (() => Promise<void>),
+  expectedUrl: string,
+  {
+    originalUrlWaitUntil = 'domcontentloaded',
+    urlWaitUntil = 'commit',
+    redirectNum = 1,
+    log = false,
+  }: {
+    originalUrlWaitUntil?: 'domcontentloaded' | 'commit' | 'load'
+    urlWaitUntil?: 'domcontentloaded' | 'commit'
+    redirectNum?: number
+    log?: boolean
+  } = {},
+) {
+  if (log) {
+    contextLog(context)
+  }
+  await page.addInitScript({
+    path: path.resolve(__dirname, './initGM.js'),
+  })
+  if (typeof originalUrl === 'function') {
+    await originalUrl()
+  } else {
+    await page.goto(originalUrl, {
+      waitUntil: originalUrlWaitUntil,
+    })
+  }
+  let newUrl = typeof originalUrl === 'function' ? await page.url() : originalUrl
+  for (let i = 0; i < redirectNum; i++) {
+    try {
+      await page.addScriptTag({
+        path: path.resolve(__dirname, '../../../../dist/remove-redirect.user.js'),
+      })
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        !error.message.includes(
+          'Execution context was destroyed, most likely because of a navigation',
+        )
+      ) {
+        throw error
+      }
+    }
+    const nowUrl = await page.url()
+    if (nowUrl.toString() !== newUrl.toString()) {
+      newUrl = nowUrl
+    } else {
+      await page.waitForURL((url) => url.toString() !== newUrl.toString(), {
+        waitUntil: urlWaitUntil,
+        timeout: 10000,
+      })
+      newUrl = await page.url()
+    }
+  }
+
+  expect(newUrl).toContain(expectedUrl)
+}
+
+export async function getTransformUrl(
+  page: Page,
+  context: BrowserContext,
+  originalUrl: string,
+  {
+    selectDomPath,
+    log = false,
+    noWait = false,
+    originalUrlWaitUntil = 'domcontentloaded',
+    waitTime = 0,
+  }: {
+    selectDomPath: string
+    originalUrlWaitUntil?: 'domcontentloaded' | 'commit' | 'load'
+    log?: boolean
+    noWait?: boolean
+    waitTime?: number
+  },
+) {
+  if (log) {
+    contextLog(context)
+  }
+
+  await page.addInitScript({
+    path: path.resolve(__dirname, './initGM.js'),
+  })
+
+  await page.goto(originalUrl, {
+    waitUntil: originalUrlWaitUntil,
+  })
+  await page.addScriptTag({
+    path: path.resolve(__dirname, '../../../../dist/remove-redirect.user.js'),
+  })
+
+  if (!waitTime) {
+    await page.waitForFunction((FEMM_ATTR_KEY) => {
+      const keyValue = document.body.getAttribute(FEMM_ATTR_KEY)
+      return keyValue === 'remove-redirect'
+    }, FEMM_ATTR_KEY)
+  } else {
+    await page.waitForTimeout(waitTime)
+  }
+  if (noWait) {
+    return await page.locator(selectDomPath).getAttribute('href')
+  }
+
+  return await page.evaluate(
+    ([selectDomPath]) => {
+      return new Promise((resolve) => {
+        const observer = new MutationObserver(() => {
+          setTimeout(() => {
+            return resolve(document.querySelector<HTMLAnchorElement>(selectDomPath)?.href)
+          })
+        })
+        observer.observe(document.body, { childList: true, subtree: true })
+      })
+    },
+    [selectDomPath],
+  )
+}
+
+function contextLog(context: BrowserContext) {
+  context.on('weberror', (webError) => {
+    console.log('🍞 ~ context.on ~ webError:', webError.error())
+  })
+  context.on('console', (msg) => {
+    console.log('🍞 ~ context.on ~ msg:', msg.type(), msg.text())
+  })
+}

--- a/packages/remove-redirect/e2e/utils/initGM.js
+++ b/packages/remove-redirect/e2e/utils/initGM.js
@@ -1,0 +1,4 @@
+window.GM = {
+  unsafeWindow: window,
+}
+window.unsafeWindow = window

--- a/packages/remove-redirect/package.json
+++ b/packages/remove-redirect/package.json
@@ -7,6 +7,7 @@
     "create-site": "node ./scripts/create-site.js",
     "update-description": "tsx ./scripts/update-description.ts && prettier --write ./metablock.json",
     "build": "rollup -c",
-    "dev": "rollup --environment BUILD:development -c --watch"
+    "dev": "rollup --environment BUILD:development -c --watch",
+    "e2e": "pnpm run build && playwright test"
   }
 }

--- a/packages/remove-redirect/playwright.config.ts
+++ b/packages/remove-redirect/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: 1,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  // reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+    headless: true,
+    bypassCSP: true,
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'Microsoft Edge',
+
+      testDir: './e2e/sites',
+      testMatch: '*.ts',
+      use: {
+        ...devices['Desktop Edge'],
+
+        locale: 'zh-CN',
+        timezoneId: 'Asia/Shanghai',
+        geolocation: { longitude: 116.3883, latitude: 39.9289 },
+      },
+    },
+  ],
+})


### PR DESCRIPTION
# 添加 Playwright E2E 测试用例

## 概述
本次PR添加了基于Playwright的端到端(E2E)测试用例，用于测试各大网站的链接重定向移除功能。

## 更新内容
- 新增49个测试用例，覆盖了以下主要功能:
  - 链接重定向移除测试
  - 搜索结果页面转换测试
  - Transform功能测试

## 测试覆盖网站
包含但不限于:
- 社交媒体: 微博、知乎、豆瓣、Facebook、YouTube等
- 技术社区: CSDN、掘金、简书、开源中国等
- 搜索引擎: 百度、Google、Bing、360等
- 在线文档: 腾讯文档、石墨文档、语雀等
- 其他平台: 哔哩哔哩、酷安、码云等

## 测试结果
- 所有49个测试用例均通过
- 测试环境: Microsoft Edge
- 平均测试执行时间: 1-4秒/用例

## 技术细节
- 使用 Playwright 作为E2E测试框架
- 测试文件位于 `sites/` 目录下
- 每个网站独立测试文件，便于维护和扩展

## 相关文档
- [Playwright 官方文档](https://playwright.dev/)

<img width="740" alt="image" src="https://github.com/user-attachments/assets/ddbe85f4-bd05-4205-8e9f-9285f6062311">
