### PR TITLE
fix(civitai-helper): update selector of rate mask buttons

### DIFF
--- a/packages/civitai-helper/src/modules/remove-rated-mask.ts
+++ b/packages/civitai-helper/src/modules/remove-rated-mask.ts
@@ -6,7 +6,7 @@
  **   - https://civitai.com/models/43331/majicmix-realistic
  ******************************************************************************/
 
-const SELECTOR = '.mantine-Stack-root > button.mantine-UnstyledButton-root.mantine-Button-root'
+const SELECTOR = 'div.pointer-events-none.absolute.left-1\\/2.top-1\\/2.z-20.flex.flex-col.items-center.gap-2.text-white > button > span > span'
 
 const ob = new IntersectionObserver((entries) => {
   for (const entry of entries) {


### PR DESCRIPTION
The old selector no longer matches any element.
The updated selector is generated by the browser DevTools, I'm not sure how long it would be valid.